### PR TITLE
switched packages from sys to util to avoid deprecation message

### DIFF
--- a/lib/mu.js
+++ b/lib/mu.js
@@ -1,4 +1,4 @@
-var sys      = require('sys'),
+var sys      = require('util'),
     fs       = require('fs'),
     path     = require('path'),
     Stream   = require('stream').Stream,

--- a/lib/mu/parser.js
+++ b/lib/mu/parser.js
@@ -1,4 +1,4 @@
-var sys    = require('sys'),
+var sys    = require('util'),
     Buffer = require('buffer').Buffer,
     
     newline = '__MU_NEWLINE__',

--- a/try.js
+++ b/try.js
@@ -1,4 +1,4 @@
-var sys = require('sys'),
+var sys = require('util'),
     mu  = require('./lib/mu');
 
 var template = "ÏHello{{#user}} {{name}}{{/user}}! " + 


### PR DESCRIPTION
Just a quick update to avoid the deprecation message that 'sys' is now 'util'. According to the node changelog this change was made at 0.3.0.  Everything works with this update and there is not longer that annoying message.

Would be _awesome_ if you could push this to npm as well. Thanks!
