### PR TITLE
Als try to resolve partials relative to the containing template

### DIFF
--- a/lib/mu.js
+++ b/lib/mu.js
@@ -11,9 +11,34 @@ var mu = module.exports = {};
 mu.root = process.cwd();
 mu.cache = {};
 
-mu.fs = function (filename, callback) {
-  filename = filename.indexOf('/') === 0 || filename.indexOf(':\\') === 1 ? filename : path.join(mu.root, filename);
-  fs.readFile(filename, 'utf8', callback);
+mu.fs = function (filename, dirname, callback) {
+  // dirname is optional, so we shift the arguments if it is omitted
+  if (!callback) {
+    callback = dirname;
+    dirname = undefined;
+  }
+
+  var filenames = [];
+  if (filename.indexOf('/') === 0 || filename.indexOf(':\\') === 1) {
+    filenames.push(filename);
+  } else {
+    filenames.push(path.join(mu.root, filename));
+    if (dirname) {
+      filenames.push(path.join(dirname, filename));
+    }
+  }
+
+  (function next() {
+    var file = filenames.shift();
+    if (file) {
+      fs.readFile(file, 'utf8', function (err, contents) {
+        if (err) next();
+        else callback(undefined, contents, file);
+      });
+    } else {
+      callback(new Error('file_not_found'));
+    }
+  }());
 }
 
 /**
@@ -24,14 +49,16 @@ mu.fs = function (filename, callback) {
  *        starts with a '/', the file is assumed to be absolute, else it is
  *        relative to mu.root.
  * @param {Function(err, Parsed)} callback The function to call when the file has been compiled.
+ * @param {Object} unique
+ * @param {String} dirname Directory to use for relative filename lookups.
  */
-mu.compile = function(filename, callback, unique) {
+mu.compile = function(filename, callback, unique, dirname) {
   var parsed,
       unique = unique || {};
   
-  mu.fs(filename, function (err, contents) {
+  mu.fs(filename, dirname, function (err, contents, found) {
     if (err) {
-      callback(new Error('file_not_found'));//errors.fileNotFound(mu.root, filename, err)));
+      return callback(err);//errors.fileNotFound(mu.root, filename, err)));
     }
     
     parsed = parser.parse(contents);
@@ -44,7 +71,7 @@ mu.compile = function(filename, callback, unique) {
       }
 
       if (i < parsed.partials.length) {
-        mu.compile(parsed.partials[i], next, unique);
+        mu.compile(parsed.partials[i], next, unique, path.dirname(found));
         i++;
         
       } else {

--- a/test/run_examples_test_no_root.js
+++ b/test/run_examples_test_no_root.js
@@ -1,0 +1,43 @@
+var assert = require('assert'),
+    fs     = require('fs'),
+    path   = require('path'),
+    mu     = require('../lib/mu');
+
+// This tests if Mu also works without using the mu.root variable, and only supplying absolute paths.
+
+mu.root = '/tmp/nonexistant';
+
+[
+  'boolean',
+  'carriage_return',
+  'comments',
+  'complex',
+  'deep_partial',
+  // 'delimiters',
+  'error_not_found',
+  'escaped',
+  'hash_instead_of_array',
+  'inverted',
+  'partial',
+  'recursion_with_same_names',
+  'reuse_of_enumerables',
+  'simple',
+  'twice',
+  'two_in_a_row',
+  'unescaped'
+].forEach(function (name) {
+  var js   = fs.readFileSync(path.join(__dirname, 'examples', name + '.js')).toString(),
+      text = fs.readFileSync(path.join(__dirname, 'examples', name + '.txt')).toString();
+  
+  js = eval('(' + js + ')');
+  
+  var buffer = '';
+
+  mu.compileAndRender(path.join(__dirname, 'examples', name + '.html'), js)
+    .on('data', function (c) { buffer += c.toString(); })
+    .on('end', function () {
+      console.log("Testing: " + name);
+      assert.equal(buffer, text);
+      console.log(name + ' passed\n');
+    });
+});


### PR DESCRIPTION
I wrote some code to also try to resolve a partial relative to the directory the referencing template is in. I also added a test file to test this behaviour, and made sure there are no regressions. (It however may cause some partials to resolve that would previously just show up as errors.)

I need this because I am serving up different sets of templates (with different 'roots') for different requests. So I can not use the mu.root setting. But invoking Mu with an absolute filename and relying on relative partials (this commit) works very well.
