### PR TITLE
Fixing issue: mu.render advertises a parse-object as the first param, but expects an array

### DIFF
--- a/lib/mu.js
+++ b/lib/mu.js
@@ -105,7 +105,8 @@ mu.render = function (filenameOrParsed, view) {
                   mu.cache[filenameOrParsed];
   
   if (parsed) {
-    return beginRender(parsed[0].tokens, view, mu.cache);
+    parsed = parsed[0] || parsed;
+    return beginRender(parsed.tokens, view, mu.cache);
   } else {
     throw new Error('template_not_in_cache'); //errors.templateNotInCache(filename)));
   }


### PR DESCRIPTION
**Issue:** mu.render advertises the parse object as the first param, but expects an array (as it gets one from the cache). Example:

```
var mu = require('mu')
  , parsed = mu.compileText('{{greeting}}, world!')
  , stream = mu.render(parsed, {greeting: 'Hello'});
stream.on('data', function (data) {
  console.log(data);
});
```

Throws the following:

```
return beginRender(parsed[0].tokens, view, mu.cache);
                            ^
TypeError: Cannot read property 'tokens' of undefined
    at Object.render (./lib/mu.js:108:33)
```
