### PR TITLE
stream.emit empty bug fixed

### DIFF
--- a/lib/mu/renderer.js
+++ b/lib/mu/renderer.js
@@ -96,7 +96,7 @@ function _render(tokens, context, partials, stream, callback) {
 
 function s(val) {
   if (val === null || typeof val === 'undefined') {
-    return '';
+    return '\0';
   } else {
     return val.toString();
   }


### PR DESCRIPTION
If you call stream.emit('data') with a empty string, mu crashes. I just fixed this by simply replacing the empty string by a end-of-stream char.