### PR TITLE
Fixed deprecation for node 0.10

### DIFF
--- a/lib/mu.js
+++ b/lib/mu.js
@@ -184,7 +184,7 @@ function beginRender(tokens, view, partials) {
 function beginRenderWithStream(tokens, view, partials, stream) {
   var count = 0;
   
-  process.nextTick(function () {
+  setImmediate(function () {
     try {
       renderer.render(tokens, view, partials, stream, function () {
         stream.emit('end');

--- a/lib/mu/renderer.js
+++ b/lib/mu/renderer.js
@@ -26,13 +26,13 @@ function _render(tokens, context, partials, stream, callback) {
     
       if (stream.paused) {
         stream.once('resumed', function () {
-          process.nextTick(next);
+          setImmediate(next);
         });
         return;
       }
 
       if (++stackSize % MAX_STACK_SIZE == 0) {
-        process.nextTick(next);
+        setImmediate(next);
         return;
       }
     
@@ -181,7 +181,7 @@ function section(context, name, val, tokens, partials, stream, callback) {
           context.pop();
 
           if (i % MAX_STACK_SIZE == 0) {
-            return process.nextTick(next);
+            return setImmediate(next);
           } else {
             next();
           }


### PR DESCRIPTION
Use `setImmediate` instead of `process.nextTick`.  This removes deprecation warnings in console.

Also fixes problem where the node process can crash with a stack overflow because it emits too many deprecation warnings too fast for itself to cope with.
