### PR TITLE
Catching parse exception in mu.compile

### DIFF
--- a/lib/mu.js
+++ b/lib/mu.js
@@ -37,9 +37,13 @@ mu.compile = function(filename, callback, unique) {
       return callback(err);
     }
     
-    parsed = parser.parse(contents);
-    mu.cache[filename] = [parsed, unique];
+    try{
+      parsed = parser.parse(contents);
+    }catch(e){
+      return callback(e);
+    }
 
+    mu.cache[filename] = [parsed, unique];
     var i = 0;
     (function next(err) {
       if (err) {


### PR DESCRIPTION
Using mu in a WS, I don't want my service to be down if there is a template error.
So I propose you a simple try catch to give the error to the callback.