### PR TITLE
Buffer.write is deprecated.

### DIFF
--- a/lib/mu/parser.js
+++ b/lib/mu/parser.js
@@ -64,7 +64,7 @@ Parser.prototype = {
         buffer  = new Buffer(Buffer.byteLength(content));
     
     if (content !== '') {
-      buffer.write(content, 'utf8', 0);
+      buffer.write(content);
       this.appendMultiContent(content);
       this.tokens.push(['static', content, buffer]);
     }


### PR DESCRIPTION
Buffer.write(string, encoding, offset, length) is deprecated. Use write(string[, offset[, length]][, encoding]) instead.

Since offset default value is `0` and encoding default value is `utf-8`, there's no need to pass these arguments.