### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,10 +5,5 @@
 , "homepage": "http://github.com/raycmorgan/mu"
 , "author" : "RayMorgan <ray@rumgr.com>"
 , "main" : "lib/mu",
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://raw.github.com/raycmorgan/Mu/master/LICENSE"
-    }
-  ]
+  "license": "MIT"
 }


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/