### PR TITLE
Replace deprecated call to Buffer.write.

### DIFF
--- a/lib/mu/parser.js
+++ b/lib/mu/parser.js
@@ -64,7 +64,7 @@ Parser.prototype = {
         buffer  = new Buffer(Buffer.byteLength(content));
     
     if (content !== '') {
-      buffer.write(content, 'utf8', 0);
+      buffer.write(content, 0, content.length, 'utf8');
       this.appendMultiContent(content);
       this.tokens.push(['static', content, buffer]);
     }


### PR DESCRIPTION
Fixes error message:
".write(string, encoding, offset, length) is deprecated. Use write(string[,
  offset[, length]][, encoding]) instead."

Fixes https://github.com/raycmorgan/Mu/issues/70