### PR TITLE
prevent exceeding stack size with many small partials

### DIFF
--- a/lib/mu/renderer.js
+++ b/lib/mu/renderer.js
@@ -1,5 +1,6 @@
 var BUFFER_LENGTH = 1024 * 8;
 var MAX_STACK_SIZE = 100;
+var stackSize = 0;
 
 var parser = require('./parser');
 var nextTick = (typeof setImmediate == 'function') ? setImmediate : process.nextTick;
@@ -20,8 +21,7 @@ function _render(tokens, context, partials, stream, callback) {
     throw new Error('Mu - WTF did you give me? I expected mustache tokens.');
   }
   
-  var i = 1
-    , stackSize = 0;
+  var i = 1;
   
   function next() {
     try {


### PR DESCRIPTION
Quick fix for the exceeding stack size issue. 