### PR TITLE
replace deprecated util.puts by console.log

### DIFF
--- a/lib/mu/parser.js
+++ b/lib/mu/parser.js
@@ -130,7 +130,7 @@ Parser.prototype = {
       break;
     
     case '=':
-      util.puts("Changing tag: " + content)
+      console.log("Changing tag: " + content)
       this.setTag(content.split(' '));
     this.appendMultiContent(tagText);
       break;


### PR DESCRIPTION
I get this error from node when using the `compileAndRender` function from mu:

> (node:6649) DeprecationWarning: util.puts is deprecated. Use console.log instead.

So I replaced the `util.puts` with `console.log`.